### PR TITLE
Adding alpine Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2-alpine
+
+RUN apk --update add --virtual build-dependencies python-dev build-base wget git
+
+RUN git clone https://github.com/boxug/trape.git
+WORKDIR /trape
+
+RUN  pip install -r requirements.txt && pip install eventlet
+EXPOSE 80
+ENTRYPOINT ["python","trape.py"]
+CMD ["--url", "https://google.com","--port","80"]


### PR DESCRIPTION
Created a alpine Dockerfile to quickly launch trape in the cloud.
Once built, it can be launched with the following:
```shell  
docker run -it -p80:80 trape
```