### PR TITLE
Preventing darwin platform to be considered as a windows os

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -71,7 +71,7 @@ class utils:
     # Loader with console cleaning and OS checking    
     @staticmethod
     def checkOS():
-        if "linux" in sys.platform:
+        if "linux" in sys.platform or sys.platform == "darwin":
             os.system("clear")
             utils.Go("Loading" + " " + utils.Color['blue'] + "trape" + utils.Color['white'] + "...")
             time.sleep(0.4)


### PR DESCRIPTION
When python is run from macOS, the `sys.platform` variable will be set to `"darwin"`. In the checkOS method, all platforms containing `"win"` are considered as Windows, hence Mac is wrong.
Given that both macOS and Linux are based on Unix, I'm setting both as accepted platforms, by comparing `sys.platform` against `"darwin"` as well.
This solves the error message in issue #31 . Though, it should still be run with `sudo` to make it work.