### PR TITLE
Typos and error fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,32 +75,32 @@ How to use it
 ```
 git clone https://github.com/jofpin/trape.git
 cd trape
-python2 trape.py -h
+python3 trape.py -h
 ```
 If it does not work, try to install all the libraries that are located in the file **requirements.txt**
 ```
-python2 -m pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Example of execution
 ```
-Example: python2 trape.py --url http://example.com --port 8080
+Example: python3 trape.py --url http://example.com --port 8080
 ```
 
 If you face some problems installing the tool, it is probably due to Python versions conflicts, you should run a Python 2.7 environment :
 
 ```
-pip install virtualenv
-virtualenv -p /usr/bin/python2.7 Vpy27
-source Vpy27/bin/activate
-pip2 install -r requirements.txt
-python2 trape.py -h
+pip3 install virtualenv
+virtualenv -p /usr/bin/python3 trape_env
+source trape_env/bin/activate
+pip3 install -r requirements.txt
+python3 trape.py -h
 ```
 
 **HELP  AND OPTIONS**
 ```
-user:~$ python2 trape.py --help
-usage: python trape.py -u <> -p <> [-h] [-v] [-u URL] [-p PORT]
+user:~$ python3 trape.py --help
+usage: python3 trape.py -u <> -p <> [-h] [-v] [-u URL] [-p PORT]
                                               [-ak ACCESSKEY] [-l LOCAL]
                                               [--update] [-n] [-ic INJC]
 

--- a/core/sockets.py
+++ b/core/sockets.py
@@ -17,7 +17,7 @@ from flask import Flask, render_template, session, request, json
 from flask_socketio import SocketIO, emit, join_room, rooms, disconnect
 import core.stats 
 import core.user
-from user_objects import attacks_hook_message
+from core.user_objects import attacks_hook_message
 from core.utils import utils
 from core.db import Database
 import sys

--- a/core/trape.py
+++ b/core/trape.py
@@ -74,7 +74,7 @@ class Trape(object):
 			if self.googl == '':
 				self.googl = 'AIzaSyDHMDTOGo9L1OBl5vRxOVM6vpXOXVp5jCc'
 			
-			parser = argparse.ArgumentParser("python3 trape.py -u <<Url>> -p <<Port>>", version=self.version)
+			parser = argparse.ArgumentParser("python3 trape.py -u <<Url>> -p <<Port>>")
 			parser.add_argument('-u', '--url', dest='url', help='Put the web page url to clone')
 			parser.add_argument('-p', '--port', dest='port', help='Insert your port')
 			parser.add_argument('-ak', '--accesskey', dest='accesskey', help='Insert your custom key access')

--- a/core/trape.py
+++ b/core/trape.py
@@ -74,7 +74,7 @@ class Trape(object):
 			if self.googl == '':
 				self.googl = 'AIzaSyDHMDTOGo9L1OBl5vRxOVM6vpXOXVp5jCc'
 			
-			parser = argparse.ArgumentParser("python trape.py -u <<Url>> -p <<Port>>", version=self.version)
+			parser = argparse.ArgumentParser("python3 trape.py -u <<Url>> -p <<Port>>", version=self.version)
 			parser.add_argument('-u', '--url', dest='url', help='Put the web page url to clone')
 			parser.add_argument('-p', '--port', dest='port', help='Insert your port')
 			parser.add_argument('-ak', '--accesskey', dest='accesskey', help='Insert your custom key access')

--- a/trape.py
+++ b/trape.py
@@ -19,7 +19,7 @@
 #**
 #
 ###############################################
-                                              #
+import os                                     #
 from core.utils import utils                  #
 from core.trape import Trape                  #
 from core.db import Database                  #
@@ -30,7 +30,7 @@ try:                                          #
     import os                                 #
 except:                                       ############################################
     utils.Go("\t\nPlease install requirements.txt libraries, you can do it executing:")  #
-    utils.Go("\t\npip install -r requirements.txt")  #####################################
+    utils.Go("\t\npip3 install -r requirements.txt")  ####################################
 ######################################################
 
 # We generalize the main class of <trape>


### PR DESCRIPTION
Launching 'trape.py' in 'core' directory caused an exception because 'version' was an unexpected keyword at line 77. For simplicity, that has been removed. (Issue: #307)

'trape.py' in the parent directory used the os module to show the hostname, but it hadn't been imported. That's been fixed.

'core/sockets.py' didn't import 'user_objects' properly (didn't mention the parent directory). That's been fixed.  (Issue: #309)

Also, since the project has been ported to python3, files that still referred to python2 have been edited.